### PR TITLE
Fix python string conversion error in abbreviate_artistsort.py

### DIFF
--- a/plugins/abbreviate_artistsort/abbreviate_artistsort.py
+++ b/plugins/abbreviate_artistsort/abbreviate_artistsort.py
@@ -157,7 +157,7 @@ def abbreviate_artistsort(tagger, metadata, track, release):
                         unsortTag,
                         unsort[i],
                     )
-                    log.warning("  Could not match surname (%s) in remaining unsorted:" % (surname, unsort))
+                    log.warning("  Could not match surname '%s' in remaining unsorted: %s" % (surname, unsort))
                     break
 
                 # Sorted:   Surname, Forename(s)...

--- a/plugins/abbreviate_artistsort/abbreviate_artistsort.py
+++ b/plugins/abbreviate_artistsort/abbreviate_artistsort.py
@@ -29,6 +29,7 @@ PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 from picard import log
 from picard.metadata import register_track_metadata_processor
 
+# NOTE: This plugin will not work consistently if you have not enabled the 'Standardize Artist Names' option!
 # The algorithm for this is complicated because the tags can contain multiple names separated by various characters
 # As an example from http://musicbrainz.org/release/6c0cfb20-2606-46c1-9306-ee5e7cb5bfdf
 #   Sorted:   Vivaldi, Antonio, Caldara, Antonio; Queyras, Jean-Guihen, Kallweit, Georg, Akademie für Alte Musik Berlin


### PR DESCRIPTION
This fixes runtime errors logged in Picard due to invalid Python string conversion.